### PR TITLE
[MERGE_READY]Bump tiiuae/fog-ros-baseimage from v2.0.0 to v2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-b1c9665 AS builder
 
 # TODO: use the same libvtk7-qt-dev-hack_1.0_all.deb hack here to make build faster
 #       (currently fails build, don't know the reason)
@@ -19,7 +19,7 @@ RUN SKIP_BUILD_UNDERLAY_STEPS=true /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-b1c9665
 
 ENTRYPOINT /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-b1c9665 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.1.0 AS builder
 
 # TODO: use the same libvtk7-qt-dev-hack_1.0_all.deb hack here to make build faster
 #       (currently fails build, don't know the reason)
@@ -19,7 +19,7 @@ RUN SKIP_BUILD_UNDERLAY_STEPS=true /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-b1c9665
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.1.0
 
 ENTRYPOINT /entrypoint.sh
 


### PR DESCRIPTION
Update fog-ros-baseimage from sha-b1c9665 to v2.1.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This baseimage update contains FastDDS SROS launch bugfix. Tested on drone and performs better when SROS is enabled.**
