### PR TITLE
Baseimage upgrade to support multi-arch builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      baseimage-dependencies:
+          patterns:
+            - "tiiuae/fog-ros-sdk"
+            - "tiiuae/fog-ros-baseimage-builder"
+            - "tiiuae/fog-ros-baseimage"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/tii-octomap-server2.yaml
+++ b/.github/workflows/tii-octomap-server2.yaml
@@ -1,17 +1,26 @@
 name: tii-octomap-server2
 
 on:
+  push:
+  pull_request:
   repository_dispatch:
     types: [fog-ros-baseimage-update]
-  push:
+  workflow_dispatch:
 
 jobs:
-  tii-octomap-server2:
+  main:
+    name: Build & push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - uses: docker/setup-buildx-action@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: amd64,riscv64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Set image tag format without suffix
         run: |
@@ -33,21 +42,24 @@ jobs:
           images: ghcr.io/tiiuae/tii-octomap-server2
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
-            type=raw,value=latest
             ${{ env.IMAGE_TAG_FORMAT }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build tii-octomap-server2 image and push
+      - name: Build image and push
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/riscv64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tii-octomap-server2.yaml
+++ b/.github/workflows/tii-octomap-server2.yaml
@@ -7,6 +7,10 @@ on:
     types: [fog-ros-baseimage-update]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   main:
     name: Build & push

--- a/.github/workflows/tii-octomap-server2.yaml
+++ b/.github/workflows/tii-octomap-server2.yaml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/tii-octomap-server2.yaml
+++ b/.github/workflows/tii-octomap-server2.yaml
@@ -3,8 +3,6 @@ name: tii-octomap-server2
 on:
   push:
   pull_request:
-  repository_dispatch:
-    types: [fog-ros-baseimage-update]
   workflow_dispatch:
 
 permissions:
@@ -16,7 +14,7 @@ jobs:
     name: Build & push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -24,42 +22,29 @@ jobs:
           platforms: amd64,riscv64,arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Set image tag format without suffix
-        run: |
-          echo "IMAGE_TAG_FORMAT=type=sha" >> $GITHUB_ENV
-        if: github.event_name == 'push'
-
-      - name: Set image tag format with suffix
-        # it is possible that run_number should be used instead run_attempt
-        # run_attempt is unique number on every run and run_attempt resets to 1 if re-build is not used
-        # content of image_sha_tag_suffix is defined in fog-ros-baseimage dispatcher workflow.
-        run: |
-          echo "IMAGE_TAG_FORMAT=type=sha,suffix=-${{ github.event.client_payload.image_sha_tag_suffix }}" >> $GITHUB_ENV
-        if: github.event_name == 'repository_dispatch'
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/tiiuae/tii-octomap-server2
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            ${{ env.IMAGE_TAG_FORMAT }}
+            type=sha
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/riscv64,linux/arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ add_definitions("-DOCTOMAP_NODEBUGOUT")
 # remove warning info from PCL
 set(PCL_FIND_QUIETLY INTERNAL)
 
+set(FPHSA_NAME_MISMATCHED 1) # Suppress warnings, see https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
@@ -26,8 +28,9 @@ find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(pcl_ros REQUIRED)
-find_package(pcl_conversions REQUIRED)
+# find_package(pcl_ros REQUIRED)
+find_package(pcl_msgs REQUIRED)
+# find_package(pcl_conversions REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(octomap REQUIRED)
 find_package(octomap_ros REQUIRED)
@@ -60,8 +63,9 @@ ament_target_dependencies(octomap_server2
   rclcpp
   rclcpp_components
   PCL
-  pcl_ros
-  pcl_conversions
+  # pcl_ros
+  pcl_msgs
+  # pcl_conversions
   sensor_msgs
   std_msgs
   nav_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(octomap_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(laser_geometry REQUIRED)
 
 find_package(Eigen3 REQUIRED)
@@ -77,6 +78,7 @@ ament_target_dependencies(octomap_server2
   octomap_msgs
   message_filters
   tf2_ros
+  tf2_geometry_msgs
   tf2_msgs
   tf2
   laser_geometry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-6d67ecf-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-6d67ecf
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.0
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-5f65a86-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-f8defd3-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-5f65a86
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-f8defd3
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-f8defd3-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-6d67ecf-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-6d67ecf
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,45 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-62e6243 AS builder
+# Given dynamically from CI job.
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-5f65a86-${TARGETARCH} AS builder
 
+# Must be defined another time after "FROM" keyword.
+ARG TARGETARCH
+
+# SRC_DIR environment variable is defined in the fog-ros-sdk image.
+# The same workspace path is used by all ROS2 components.
+# See: https://github.com/tiiuae/fog-ros-baseimage/blob/main/Dockerfile.sdk_builder
 COPY . $SRC_DIR/octomap_server2
 
-RUN apt update && \
-    apt install -y octomap-staticdev
+RUN /packaging/build_colcon_sdk.sh ${TARGETARCH}
+# Even though it is possible to tar the install directory for retrieving it later in runtime image,
+# the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-RUN /packaging/build_colcon.sh
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-5f65a86
 
-#  ▲               runtime ──┐
-#  └── build                 ▼
-
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-62e6243
-
-RUN apt update && \
-    apt install -y octomap-staticdev \
+RUN apt update \
+    && apt install -y --no-install-recommends \
+    octomap-staticdev \
     pcl-ros \
     pcl-conversions \
     pcl-msgs \
     octomap-ros \
     octomap-msgs \
     laser-geometry \
-    boost
+    boost \
+    && rm -rf /var/lib/apt/lists/*
 
+HEALTHCHECK --interval=5s \
+	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \
+		--metrics-from=http://localhost:${METRICS_PORT}/metrics --only-if-nonempty=${METRICS_PORT}
+
+# launch file checks env variables SIMULATION and DRONE_AIRFRAME
+# SIMULATION is by default 0. However, it can be set to 1
+# DRONE_AIRFRAME is by default "t-drone". However, it can be set to "holybro"
 ENTRYPOINT [ "/entrypoint.sh" ]
+
 COPY entrypoint.sh /entrypoint.sh
 
-COPY --from=builder $INSTALL_DIR $INSTALL_DIR
+# WORKSPACE_DIR environment variable is defined in the fog-ros-baseimage.
+# The same installation directory is used by all ROS2 components.
+# See: https://github.com/tiiuae/fog-ros-baseimage/blob/main/Dockerfile
+WORKDIR $WORKSPACE_DIR
+COPY --from=builder $WORKSPACE_DIR/install install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-c549c2f AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:sha-62e6243 AS builder
 
 COPY . $SRC_DIR/octomap_server2
 
@@ -10,7 +10,7 @@ RUN /packaging/build_colcon.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c549c2f
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-62e6243
 
 RUN apt update && \
     apt install -y octomap-staticdev \
@@ -20,8 +20,6 @@ RUN apt update && \
     octomap-ros \
     octomap-msgs \
     laser-geometry \
-    rosidl-generator-py \
-    rosidl-generator-c \
     boost
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-5f65a86-${TARGETARCH} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-5f65a86-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -9,7 +9,7 @@ ARG TARGETARCH
 # See: https://github.com/tiiuae/fog-ros-baseimage/blob/main/Dockerfile.sdk_builder
 COPY . $SRC_DIR/octomap_server2
 
-RUN /packaging/build_colcon_sdk.sh ${TARGETARCH}
+RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-f8defd3
-
-RUN apt update \
-    && apt install -y --no-install-recommends \
-    octomap-staticdev \
-    pcl-ros \
-    pcl-conversions \
-    pcl-msgs \
-    octomap-ros \
-    octomap-msgs \
-    laser-geometry \
-    boost \
-    && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/tiiuae/fog-ros-baseimage:feat-multiarch-pkcs11
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \
@@ -38,8 +26,21 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 
 COPY entrypoint.sh /entrypoint.sh
 
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        octomap-staticdev \
+        pcl-ros \
+        pcl-conversions \
+        pcl-msgs \
+        octomap-ros \
+        octomap-msgs \
+        laser-geometry \
+        boost \
+    && rm -rf /var/lib/apt/lists/*
+
 # WORKSPACE_DIR environment variable is defined in the fog-ros-baseimage.
 # The same installation directory is used by all ROS2 components.
 # See: https://github.com/tiiuae/fog-ros-baseimage/blob/main/Dockerfile
 WORKDIR $WORKSPACE_DIR
+
 COPY --from=builder $WORKSPACE_DIR/install install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.1-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -13,7 +13,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.1
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \

--- a/README.md
+++ b/README.md
@@ -6,20 +6,17 @@ Implements occupancy 3D grid mapping by computing occupied "cells" from
 
 Port of the ROS1 [octomap server](https://github.com/OctoMap/octomap_mapping) for ROS2.0 
 
-
-Development, debug
-------------------
+## Development, debug
 
 [See documentation in container base image](https://github.com/tiiuae/fog-ros-baseimage/tree/main#development--debug-for-concrete-projects)
 
 
-Outdated documentation
-----------------------
+## Outdated documentation
 
 **WARNING**: Rest of the docs are outdated regarding container-specific build/running.
 
 
-#### Installation
+## Installation
 1.  Firstly make sure you have [octomap](https://github.com/OctoMap/octomap.git) installed on your system 
   ```bash
   sudo apt-get install ros-galactic-octomap ros-galactic-octomap-msgs
@@ -30,11 +27,14 @@ Outdated documentation
   git clone https://github.com/fly4future/octomap_server2.git
   ```
 
-#### Building
+## Building
+
 Use colcon to build the workspace
+
 ```bash
 colcon build --symlink-install --packages-select octomap_server2
 ```
 
 ### Notes:
+
 - The package is compiled using `c++17` with `-O3` optimization.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -e
-
+source /usr/bin/ros_setup.bash
+source /main_ws/install/setup.bash
 _term() {
 	# FILL UP PROCESS SEARCH PATTERN HERE TO FIND PROPER PROCESS FOR SIGINT:
 	pattern="component_container_mt"
 
-	pid_value="$(ps -ax | grep $pattern | grep -v grep | awk '{ print $1 }')"
+	pid_value="$(ps -e | grep $pattern | grep -v grep | awk '{ print $1 }')"
 	if [ "$pid_value" != "" ]; then
 		pid=$pid_value
 		echo "Send SIGINT to pid $pid"
@@ -22,7 +23,7 @@ if [[ ${SIMULATION+x} != "" ]]; then
 	ROS_FLAGS="use_sim_time:=true ${ROS_FLAGS}"
 fi
 
-ros-with-env ros2 launch octomap_server2 octomap_server.py ${ROS_FLAGS} &
+ros-with-env ros2 launch octomap_server2 octomap_server_launch.py ${ROS_FLAGS} &
 child=$!
 
 echo "Waiting for pid $child"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -e
-source /usr/bin/ros_setup.bash
-source /main_ws/install/setup.bash
 _term() {
 	# FILL UP PROCESS SEARCH PATTERN HERE TO FIND PROPER PROCESS FOR SIGINT:
 	pattern="component_container_mt"
@@ -23,7 +21,7 @@ if [[ ${SIMULATION+x} != "" ]]; then
 	ROS_FLAGS="use_sim_time:=true ${ROS_FLAGS}"
 fi
 
-ros-with-env ros2 launch octomap_server2 octomap_server_launch.py ${ROS_FLAGS} &
+ros-with-env ros2 launch octomap_server2 octomap_server.py ${ROS_FLAGS} &
 child=$!
 
 echo "Waiting for pid $child"

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -49,6 +49,7 @@
 #include <eigen3/Eigen/Geometry>
 
 // #include <pcl_ros/transforms.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <pcl_msgs/msg/point_indices.hpp>

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -48,7 +48,10 @@
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Geometry>
 
-#include <pcl_ros/transforms.hpp>
+// #include <pcl_ros/transforms.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <pcl_msgs/msg/point_indices.hpp>
 #include <pcl/point_types.h>
 #include <pcl/conversions.h>
 #include <pcl/io/pcd_io.h>
@@ -153,6 +156,18 @@ private:
   rclcpp::TimerBase::SharedPtr timer_local_map_resizer_;
   void       timerLocalMapResizer();
 
+  /** \brief Obtain the transformation matrix from TF into an Eigen form
+    * \param bt the TF transformation
+    * \param out_mat the Eigen transformation
+    */
+  void transformAsMatrix(const tf2::Transform & bt, Eigen::Matrix4f & out_mat);
+
+  /** \brief Obtain the transformation matrix from TF into an Eigen form
+    * \param bt the TF transformation
+    * \param out_mat the Eigen transformation
+    */
+  void transformAsMatrix(const geometry_msgs::msg::TransformStamped & bt, Eigen::Matrix4f & out_mat);
+
   // | ----------------------- parameters ----------------------- |
 
   std::atomic<bool> is_initialized_     = false;
@@ -238,7 +253,7 @@ private:
   bool createLocalMap(const std::string frame_id, const double horizontal_distance, const double vertical_distance, std::shared_ptr<OcTree_t>& octree);
 
   virtual void insertPointCloud(const geometry_msgs::msg::Vector3& robotOrigin, const geometry_msgs::msg::Vector3& sensorOrigin, 
-                                const PCLPointCloud::ConstPtr& cloud, const PCLPointCloud::ConstPtr& free_cloud);
+                                const std::shared_ptr<const PCLPointCloud>& cloud, const std::shared_ptr<const PCLPointCloud>& free_cloud);
 
   // sensor model
   double _probHit_;

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <build_depend>octomap_ros</build_depend>
   <build_depend>octomap_msgs</build_depend>
   <build_depend>laser_geometry</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_xml</exec_depend>
@@ -48,6 +49,7 @@
   <exec_depend>octomap_ros</exec_depend>
   <exec_depend>octomap_msgs</exec_depend>
   <exec_depend>laser_geometry</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR brings the functionality to build component in amd64, arm64, and riscv64 architectures.

For further information about the baseimage related changes, see [fog-ros-baseimage/docs
/Multiarchitecture_builds.md](https://github.com/tiiuae/fog-ros-baseimage/blob/main/docs/Multiarchitecture_builds.md)

Merge of this PR will be done by the fog-ros-baseimage maintainers.
