### PR TITLE
implement metrics, fix health check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(laser_geometry REQUIRED)
+find_package(prometheus-cpp CONFIG REQUIRED)
 
 find_package(Eigen3 REQUIRED)
 set(Eigen_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS})
@@ -84,7 +85,7 @@ ament_target_dependencies(octomap_server2
   laser_geometry
   )
 
-target_link_libraries(octomap_server2 ${EIGEN3_LIBRARIES} ${PCL_LIBRARIES} ${OCTOMAP_LIBRARIES})
+target_link_libraries(octomap_server2 ${EIGEN3_LIBRARIES} ${PCL_LIBRARIES} ${OCTOMAP_LIBRARIES} prometheus-cpp::pull)
 
 rclcpp_components_register_node(octomap_server2
   PLUGIN "octomap_server::OctomapServer"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.2
 
 HEALTHCHECK --interval=5s \
-	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \
+	CMD fog-health check --metric=octomap_result_publish_count --diff-gte=1.0 \
 		--metrics-from=http://localhost:${METRICS_PORT}/metrics --only-if-nonempty=${METRICS_PORT}
 
 # launch file checks env variables SIMULATION and DRONE_AIRFRAME

--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -69,6 +69,10 @@
 
 #include <laser_geometry/laser_geometry.hpp>
 
+#include <prometheus/counter.h>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
 #include "octomap_server2/octomap_server.hpp"
 
 #include <cmath>
@@ -136,6 +140,12 @@ private:
 
   rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr pub_map_local_full_;
   rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr pub_map_local_binary_;
+
+  // | -------------------- metrics -------------------- |
+
+  std::shared_ptr<prometheus::Registry> metrics_registry = std::make_shared<prometheus::Registry>();
+  std::shared_ptr<prometheus::Exposer> metrics_exposer;
+  prometheus::Counter* result_publish_count;
 
   // | -------------------- service serviers -------------------- |
 


### PR DESCRIPTION
I had accidentally set to `Dockerfile` a health check that did not work.

Finally fix it.

Bonus change is @jari-hodju 's changes to make this build due to GH action builder running out of disk space

## Testing

Tested by @MaritaHaavisto from this [fog_system branch](https://github.com/tiiuae/fog_system/commit/1b9e87ae1ac2f4974a622b9194aff0e954772585) to now show us as healthy:

```
🟩 $hypervisor.octomap-server | 
```